### PR TITLE
IOpipe core as peer dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Create marks and measures for arbitrary units of time. Measure latency of databa
 ## Requirements
 - Node >= `4.3.2`
 - NPM >= `2.14.12`
-- IOpipe >= `0.8.0`
+- [IOpipe](https://github.com/iopipe/iopipe-js) >= `1.x`
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "homepage": "https://github.com/iopipe/iopipe-plugin-trace#readme",
   "devDependencies": {
+    "@iopipe/core": "^1.x",
     "aws-lambda-mock-context": "^3.0.0",
     "babel-cli": "^6.24.1",
     "babel-core": "^6.25.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "prettier": "^1.5.2"
   },
   "dependencies": {
-    "@iopipe/core": "^1.5.0",
     "performance-node": "^0.2.0"
   },
   "pre-commit": [
@@ -61,5 +60,8 @@
       "/node_modules/",
       "dist"
     ]
+  },
+  "peerDependencies": {
+    "@iopipe/core": "1.x"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@iopipe/core@1.x":
+"@iopipe/core@^1.x":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@iopipe/core/-/core-1.5.0.tgz#40d47861fadca698cd42d2af2d7f82e0914eb194"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@iopipe/core@^1.5.0":
+"@iopipe/core@1.x":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@iopipe/core/-/core-1.5.0.tgz#40d47861fadca698cd42d2af2d7f82e0914eb194"
   dependencies:


### PR DESCRIPTION
Since this is a plugin and "should not" specify iopipe as a dependency, it should be moved to a peer dependency.

https://nodejs.org/en/blog/npm/peer-dependencies/