### PR TITLE
fix(data-collection) Limit header collection further

### DIFF
--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -23,10 +23,6 @@ Array [
     "response": Object {
       "headers": Array [
         Object {
-          "key": "vary",
-          "string": "Accept-Encoding",
-        },
-        Object {
           "key": "server",
           "string": "Netlify",
         },
@@ -59,10 +55,6 @@ Array [
     },
     "response": Object {
       "headers": Array [
-        Object {
-          "key": "vary",
-          "string": "Accept-Encoding",
-        },
         Object {
           "key": "server",
           "string": "Netlify",
@@ -101,10 +93,6 @@ Array [
     "response": Object {
       "headers": Array [
         Object {
-          "key": "vary",
-          "string": "Accept-Encoding",
-        },
-        Object {
           "key": "server",
           "string": "Netlify",
         },
@@ -141,10 +129,6 @@ Object {
   },
   "response": Object {
     "headers": Array [
-      Object {
-        "key": "vary",
-        "string": "Accept-Encoding",
-      },
       Object {
         "key": "server",
         "string": "Netlify",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import Perf from 'performance-node';
 
-import pkg from '../package';
+import pkg from '../package.json'; // eslint-disable-line import/extensions
 import { addToReport, addHttpTracesToReport } from './addToReport';
 import { wrap as httpWrap, unwrap as httpUnwrap } from './shimmerHttp';
 

--- a/src/shimmerHttp.js
+++ b/src/shimmerHttp.js
@@ -101,7 +101,6 @@ function getResDataObject(res) {
 const defaultKeysToRecord = new Map(
   [
     'request.hash',
-    'request.headers.accept-encoding',
     'request.headers.user-agent',
     'request.hostname',
     'request.method',
@@ -111,17 +110,9 @@ const defaultKeysToRecord = new Map(
     'request.protocol',
     'request.query',
     'request.url',
-    'response.headers.age',
-    'response.headers.cache-control',
-    'response.headers.connection',
-    'response.headers.content-encoding',
     'response.headers.content-length',
     'response.headers.content-type',
-    'response.headers.date',
-    'response.headers.etag',
     'response.headers.server',
-    'response.headers.strict-transport-security',
-    'response.headers.vary',
     'response.statusCode',
     'response.statusMessage'
   ].map(s => [s])


### PR DESCRIPTION
Limit header collection further, fixes #31
- also updates import of package.json to have extension; this will address https://github.com/iopipe/iopipe-js-logger/issues/20 for this plugin