### PR TITLE
Fix double-capture of traces

### DIFF
--- a/src/plugins/https.test.js
+++ b/src/plugins/https.test.js
@@ -25,6 +25,9 @@ function iopipeComExpect(
   Object.keys(reqHeaders).forEach(header => {
     expect(obj[`request.${header}`]).toBe(reqHeaders[header]);
   });
+  expect(obj['request.headers.Authorization']).toBeUndefined();
+  expect(obj['request.headers.authorization']).toBeUndefined();
+
   expect(obj['response.headers.content-type']).toBe(contentType);
   expect(obj['response.statusCode']).toBe(statusCode);
 

--- a/src/plugins/ioredis.test.js
+++ b/src/plugins/ioredis.test.js
@@ -69,7 +69,7 @@ test('Bails if timeline is not instance of performance-node', () => {
   expect(bool).toBe(false);
 });
 
-describe('Wrapping Redis', () => {
+describe('Wrapping Redis Mock', () => {
   afterEach(() => {
     unwrap();
   });
@@ -92,8 +92,14 @@ describe('Wrapping Redis', () => {
 
     // not doing timelineExpect because mock doesn't affect timeline
   });
+});
 
-  xtest(
+xdescribe('Wrapping Redis', () => {
+  afterEach(() => {
+    unwrap();
+  });
+
+  test(
     'Wrap works with redis.set and redis.get using async/await syntax',
     async () => {
       const timeline = new Perf({ timestamp: true });
@@ -117,7 +123,7 @@ describe('Wrapping Redis', () => {
     15000
   );
 
-  xtest(
+  test(
     'Wrap works with redis.set/get using promise syntax',
     async () => {
       const timeline = new Perf({ timestamp: true });
@@ -150,7 +156,7 @@ describe('Wrapping Redis', () => {
     15000
   );
 
-  xtest(
+  test(
     'Wrap works with redis.set/get using callback syntax',
     done => {
       const timeline = new Perf({ timestamp: true });

--- a/yarn.lock
+++ b/yarn.lock
@@ -103,6 +103,7 @@
 "@iopipe/scripts@^1.4.1":
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/@iopipe/scripts/-/scripts-1.4.1.tgz#67c5012dfbc4d43875683786f450ebac9ed20117"
+  integrity sha512-sKuF5fV1N1icRgX0It9rSLICYAstCjBA4TcfzZdVNdEXpDKUbWvgiozrQgH1WMGgeudqs8dbEaEiBACaCRl+eQ==
   dependencies:
     "@iopipe/eslint-config-iopipe" "1.0.2"
     "@ljharb/eslint-config" "^12.2.1"


### PR DESCRIPTION
Wrapping the wrapping (inception!) of initPromise in a conditional for the beta.  There's value in wrapping callbacks, but in this version, the wrap of initPromise generates effectively content-free traces.  There's more actionable information from wrapping Redis.prototype.sendCommand.

Also includes explicit tests of http headers, to ensure that we're not capturing authorization headers.