### PR TITLE
Fix for stuck http-auto-trace

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Automatically create traces and matching metadata for each http/s call made with
 
 #### `autoHttp.enabled` (bool: optional = false)
 
-Enable HTTP/S auto-tracing. Disabled by default. You can also use the environment variable `IOPIPE_TRACE_AUTO_HTTP_ENABLED`.
+Enable HTTP/S auto-tracing. Enabled by default. You can also use the environment variable `IOPIPE_TRACE_AUTO_HTTP_ENABLED`.
 
 #### `autoHttp.filter` (func: optional)
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import { addToReport, addTraceData } from './addToReport';
 const plugins = {
   https: {
     config: 'autoHttp',
-    enabled: true,
+    flag: 'IOPIPE_TRACE_AUTO_HTTP_ENABLED',
     entries: 'httpTraceEntries'
   },
   ioredis: {
@@ -35,7 +35,12 @@ function getBooleanFromEnv(key = '') {
 function getConfig(config = {}) {
   const {
     autoMeasure = true,
-    autoHttp = { enabled: true },
+    autoHttp = {
+      enabled:
+        typeof process.env.IOPIPE_TRACE_AUTO_HTTP_ENABLED === 'undefined'
+          ? true
+          : getBooleanFromEnv('IOPIPE_TRACE_AUTO_HTTP_ENABLED')
+    },
     autoIoRedis = { enabled: getBooleanFromEnv('IOPIPE_TRACE_IOREDIS') },
     autoRedis = { enabled: getBooleanFromEnv('IOPIPE_TRACE_REDIS') }
   } = config;
@@ -74,7 +79,6 @@ function addTimelineMeasures(pluginInstance, timelineArg) {
     .map(entry => entry.name);
   // loop through each mark and make sure there is a start and end
   // if so, measure
-  // console.log('NAMES', names);
   names.forEach(name => {
     if (name.match(/^(start):.+/)) {
       const baseName = name.replace(/(start|end):(.+)/, '$2');

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -64,6 +64,26 @@ test('Can instantiate the plugin with no options', () => {
   expect(inst.meta.homepage).toBe(pkg.homepage);
 });
 
+test('http trace can be turned off via env var', () => {
+  process.env.IOPIPE_TRACE_AUTO_HTTP_ENABLED = false;
+  const plugin = tracePlugin();
+  const inst = plugin({});
+  expect(inst.config.autoHttp.enabled).toBe(false);
+});
+
+test('http trace can be turned on via env var', () => {
+  process.env.IOPIPE_TRACE_AUTO_HTTP_ENABLED = true;
+  const plugin = tracePlugin();
+  const inst = plugin({});
+  expect(inst.config.autoHttp.enabled).toBe(true);
+});
+
+test('http trace is on if not otherwise defined', () => {
+  const plugin = tracePlugin();
+  const inst = plugin({});
+  expect(inst.config.autoHttp.enabled).toBe(true);
+});
+
 test('Works with iopipe', async () => {
   try {
     let inspectableInv, testStartDate, testEndDate;

--- a/src/plugins/redis.test.js
+++ b/src/plugins/redis.test.js
@@ -20,7 +20,22 @@ const mockSet = (key, val) => {
   return { key: val };
 };
 
-jest.mock('redis').default;
+const mockRedis = jest.fn();
+
+/*eslint-disable babel/no-invalid-this*/
+/*eslint-disable func-name-matching */
+/*eslint-disable prefer-rest-params */
+/*eslint-disable func-names */
+/*eslint-disable camelcase */
+
+mockRedis.mockImplementation(function() {
+  const context = this;
+  this.RedisClient = jest.fn(() => {});
+  this.internal_send_command = jest.fn(() => {});
+  this.set = jest.fn((key, val) => mockSet(key, val));
+  this.get = jest.fn(key => mockGet(key));
+  this.createClient = jest.fn(() => context);
+});
 
 function timelineExpect({ timeline, data }) {
   const dataValues = _.values(data);
@@ -37,7 +52,8 @@ function timelineExpect({ timeline, data }) {
 }
 
 test('Basic Redis mock works as normal if wrap is not called', () => {
-  const client = redis.createClient();
+  const m = new mockRedis(); //eslint-disable-line babel/new-cap
+  const client = m.createClient();
   client.set = jest.fn((key, val) => mockSet(key, val));
   client.get = jest.fn(key => mockGet(key));
 


### PR DESCRIPTION
Allowing http env var to be set from environment. True if not defined.
Correction to README on https auto-trace enabling.
Correction to redis mock, for passing CircleCI