### PR TITLE
Refactor to load plugins from different paths for layer installations

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,8 @@
 import Perf from 'performance-node';
-
 import pkg from '../package.json'; // eslint-disable-line import/extensions
 import { addToReport, addTraceData } from './addToReport';
 
-const load = plugin => {
+const loadPlugin = plugin => {
   /*eslint-disable camelcase, no-undef*/
   if (typeof __non_webpack_require__ === 'function') {
     return __non_webpack_require__(`./plugins/${plugin}`);
@@ -144,7 +143,7 @@ class TracePlugin {
 
       if (context.config[conf] && context.config[conf].enabled) {
         // getting plugin; allows this to be loaded only if enabled.
-        await load(`${k}`).then(mod => {
+        await loadPlugin(`${k}`).then(mod => {
           plugins[k].wrap = mod.wrap;
           plugins[k].unwrap = mod.unwrap;
           context[namespace] = {

--- a/src/loadHelper.js
+++ b/src/loadHelper.js
@@ -1,0 +1,52 @@
+import { debuglog } from 'util';
+
+const debug = debuglog('@iopipe:trace:loadHelper');
+
+// The module being traced might not be in the lambda NODE_PATH,
+// particularly if IOpipe has been installed with lambda layers.
+// So here's an attempt at a fallback.
+
+const deriveTargetPath = manualPath => {
+  const path = manualPath ? manualPath : process.env.LAMBDA_TASK_ROOT;
+  if (!path) {
+    return false;
+  }
+  const targetPath = `${path}/node_modules`;
+  process.env.IOPIPE_TARGET_PATH = targetPath;
+  return targetPath;
+};
+
+const appendToPath = manualPath => {
+  if (!process.env || !process.env.NODE_PATH) {
+    return false;
+  }
+  const targetPath = deriveTargetPath(manualPath);
+  const pathArray = process.env.NODE_PATH.split(':');
+  if (!targetPath && pathArray.indexOf(targetPath) === -1) {
+    process.env.NODE_PATH = `${process.env.NODE_PATH}:${targetPath}`;
+  }
+  return targetPath;
+};
+
+appendToPath();
+
+const loadModuleForTracing = async (module, path) => {
+  const targetPath = path ? path : process.env.IOPIPE_TARGET_PATH;
+  let loadedModule;
+  try {
+    loadedModule = await require(module);
+  } catch (e) {
+    debug(`Unable to load ${module} from require; trying TASK_ROOT path.`, e);
+    try {
+      if (targetPath) {
+        loadedModule = await require(`${targetPath}/${module}`);
+      }
+    } catch (err) {
+      debug(`Unable to load ${module} from path ${targetPath}`, err);
+    }
+  }
+
+  return loadedModule;
+};
+
+export default loadModuleForTracing;

--- a/src/plugins/https.js
+++ b/src/plugins/https.js
@@ -9,7 +9,7 @@ import pickBy from 'lodash.pickby';
 import isArray from 'isarray';
 import { flatten } from 'flat';
 
-const debug = debuglog('@iopipe/trace');
+const debug = debuglog('@iopipe:trace:https');
 
 /*eslint-disable babel/no-invalid-this*/
 


### PR DESCRIPTION
Refactoring plugin loading to use alternate paths in a layers environment.
Addresses ioredis, redis, and mongodb.
Adds no-op if plugin is not found. 