### PR TITLE
Fallback for loading plugins in layers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -143,8 +143,8 @@ class TracePlugin {
 
       if (context.config[conf] && context.config[conf].enabled) {
         // getting plugin; allows this to be loaded only if enabled.
-        await loadPlugin(`${k}`).then(async mod => {
-          plugins[k].wrap = await mod.wrap;
+        await loadPlugin(`${k}`).then(mod => {
+          plugins[k].wrap = mod.wrap;
           plugins[k].unwrap = mod.unwrap;
           context[namespace] = {
             timeline: new Perf({ timestamp: true }),
@@ -152,7 +152,7 @@ class TracePlugin {
             data: {},
             config: context.config[conf]
           };
-          plugins[k].wrap(context[namespace]);
+          return plugins[k].wrap(context[namespace]);
         });
       }
     });

--- a/src/index.js
+++ b/src/index.js
@@ -143,8 +143,8 @@ class TracePlugin {
 
       if (context.config[conf] && context.config[conf].enabled) {
         // getting plugin; allows this to be loaded only if enabled.
-        await loadPlugin(`${k}`).then(mod => {
-          plugins[k].wrap = mod.wrap;
+        await loadPlugin(`${k}`).then(async mod => {
+          plugins[k].wrap = await mod.wrap;
           plugins[k].unwrap = mod.unwrap;
           context[namespace] = {
             timeline: new Perf({ timestamp: true }),

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,8 @@
 import Perf from 'performance-node';
-
 import pkg from '../package.json'; // eslint-disable-line import/extensions
 import { addToReport, addTraceData } from './addToReport';
 
-const load = plugin => {
+const loadPlugin = plugin => {
   /*eslint-disable camelcase, no-undef*/
   if (typeof __non_webpack_require__ === 'function') {
     return __non_webpack_require__(`./plugins/${plugin}`);
@@ -144,7 +143,7 @@ class TracePlugin {
 
       if (context.config[conf] && context.config[conf].enabled) {
         // getting plugin; allows this to be loaded only if enabled.
-        await load(`${k}`).then(mod => {
+        await loadPlugin(`${k}`).then(mod => {
           plugins[k].wrap = mod.wrap;
           plugins[k].unwrap = mod.unwrap;
           context[namespace] = {

--- a/src/loadHelper.js
+++ b/src/loadHelper.js
@@ -1,0 +1,52 @@
+import { debuglog } from 'util';
+
+const debug = debuglog('@iopipe:trace:loadHelper');
+
+// The module being traced might not be in the lambda NODE_PATH,
+// particularly if IOpipe has been installed with lambda layers.
+// So here's an attempt at a fallback.
+
+const deriveTargetPath = manualPath => {
+  const path = manualPath ? manualPath : process.env.LAMBDA_TASK_ROOT;
+  if (!path) {
+    return false;
+  }
+  const targetPath = `${path}/node_modules`;
+  process.env.IOPIPE_TARGET_PATH = targetPath;
+  return targetPath;
+};
+
+const appendToPath = manualPath => {
+  if (!process.env || !process.env.NODE_PATH) {
+    return false;
+  }
+  const targetPath = deriveTargetPath(manualPath);
+  const pathArray = process.env.NODE_PATH.split(':');
+  if (!targetPath && pathArray.indexOf(targetPath) === -1) {
+    process.env.NODE_PATH = `${process.env.NODE_PATH}:${targetPath}`;
+  }
+  return targetPath;
+};
+
+appendToPath();
+
+const loadModuleForTracing = async (module, path) => {
+  const targetPath = path ? path : process.env.IOPIPE_TARGET_PATH;
+  let loadedModule;
+  try {
+    loadedModule = await require(module);
+  } catch (e) {
+    debug(`Unable to load ${module} from require; trying TASK_ROOT path.`, e);
+    try {
+      if (targetPath) {
+        loadedModule = await require(`${targetPath}/${module}`);
+      }
+    } catch (err) {
+      debug(`Unable to load ${module} from path ${targetPath}`, err);
+    }
+  }
+
+  return loadedModule;
+};
+
+export default loadModuleForTracing;

--- a/src/plugins/https.js
+++ b/src/plugins/https.js
@@ -9,7 +9,7 @@ import pickBy from 'lodash.pickby';
 import isArray from 'isarray';
 import { flatten } from 'flat';
 
-const debug = debuglog('@iopipe/trace');
+const debug = debuglog('@iopipe:trace:https');
 
 /*eslint-disable babel/no-invalid-this*/
 

--- a/src/plugins/ioredis.js
+++ b/src/plugins/ioredis.js
@@ -8,15 +8,16 @@ const debug = debuglog('@iopipe:trace:ioredis');
 
 let Redis;
 
-loadModuleForTracing('ioredis')
-  .then(module => {
-    Redis = module;
-    return module;
-  })
-  .catch(e => {
-    debug('Not loading ioredis', e);
-    return false;
-  });
+const loadModule = async () =>
+  loadModuleForTracing('ioredis')
+    .then(module => {
+      Redis = module;
+      return module;
+    })
+    .catch(e => {
+      debug('Not loading ioredis', e);
+      return false;
+    });
 
 /*eslint-disable babel/no-invalid-this*/
 /*eslint-disable func-name-matching */
@@ -40,7 +41,8 @@ const filterRequest = (command, context) => {
   };
 };
 
-function wrap({ timeline, data = {} } = {}) {
+async function wrap({ timeline, data = {} } = {}) {
+  await loadModule();
   if (!Redis) {
     debug('ioredis plugin not accessible from trace plugin. Skipping.');
     return false;

--- a/src/plugins/ioredis.test.js
+++ b/src/plugins/ioredis.test.js
@@ -64,8 +64,8 @@ xtest('Redis works as normal if wrap is not called', done => {
     });
 });
 
-test('Bails if timeline is not instance of performance-node', () => {
-  const bool = wrap({ timeline: [] });
+test('Bails if timeline is not instance of performance-node', async () => {
+  const bool = await wrap({ timeline: [] });
   expect(bool).toBe(false);
 });
 
@@ -128,7 +128,7 @@ xdescribe('Wrapping Redis', () => {
         db: 1
       });
 
-      expect(redis.sendCommand.__wrapped).toBeDefined();
+      expect(redis.__wrapped).toBeDefined();
 
       const expectedStr = 'wrapped ioredis, async/await';
 
@@ -152,7 +152,7 @@ xdescribe('Wrapping Redis', () => {
 
       redis = new Redis({ host: '127.0.0.1', connectionName: 'Test 2', db: 1 });
 
-      expect(redis.sendCommand.__wrapped).toBeDefined();
+      expect(redis.__wrapped).toBeDefined();
 
       const expectedStr = 'wrapped ioredis, promise syntax';
 
@@ -185,7 +185,7 @@ xdescribe('Wrapping Redis', () => {
 
       redis = new Redis({ host: 'localhost', connectionName: 'Test 3', db: 1 });
 
-      expect(redis.sendCommand.__wrapped).toBeDefined();
+      expect(redis.__wrapped).toBeDefined();
 
       const expectedStr = 'wrapped ioredis, callback syntax';
       redis.set('testString', expectedStr);

--- a/src/plugins/mongodb.js
+++ b/src/plugins/mongodb.js
@@ -16,24 +16,27 @@ let MongoClient,
   serverTarget,
   cursorTarget;
 
-loadModuleForTracing('mongodb')
-  .then(module => {
-    MongoClient = module.MongoClient;
-    Server = module.Server;
-    Cursor = module.Cursor;
-    Collection = module.Collection;
+const loadModule = async () => {
+  const mod = await loadModuleForTracing('mongodb')
+    .then(module => {
+      MongoClient = module.MongoClient;
+      Server = module.Server;
+      Cursor = module.Cursor;
+      Collection = module.Collection;
 
-    clientTarget = MongoClient && MongoClient.prototype;
-    collectionTarget = Collection && Collection.prototype;
-    serverTarget = Server && Server.prototype;
-    cursorTarget = Cursor && Cursor.prototype;
+      clientTarget = MongoClient && MongoClient.prototype;
+      collectionTarget = Collection && Collection.prototype;
+      serverTarget = Server && Server.prototype;
+      cursorTarget = Cursor && Cursor.prototype;
 
-    return module;
-  })
-  .catch(e => {
-    debug('Not loading mongodb', e);
-    return null;
-  });
+      return module;
+    })
+    .catch(e => {
+      debug('Not loading mongodb', e);
+      return null;
+    });
+  return mod;
+};
 
 const dbType = 'mongodb';
 const serverOps = ['command', 'insert', 'update', 'remove'];
@@ -169,7 +172,9 @@ const filterRequest = (params, context) => {
   };
 };
 
-function wrap({ timeline, data = {} } = {}) {
+async function wrap({ timeline, data = {} } = {}) {
+  await loadModule();
+
   if (!clientTarget) {
     debug('mongodb plugin not accessible from trace plugin. Skipping.');
     return false;

--- a/src/plugins/redis.js
+++ b/src/plugins/redis.js
@@ -9,15 +9,16 @@ let redis;
 
 const debug = debuglog('@iopipe:trace:redis');
 
-loadModuleForTracing('redis')
-  .then(module => {
-    redis = module;
-    return module;
-  })
-  .catch(e => {
-    debug('Not loading redis', e);
-    return false;
-  });
+const loadModule = async () =>
+  loadModuleForTracing('redis')
+    .then(module => {
+      redis = module;
+      return module;
+    })
+    .catch(e => {
+      debug('Not loading redis', e);
+      return false;
+    });
 
 /*eslint-disable babel/no-invalid-this*/
 /*eslint-disable func-name-matching */
@@ -43,7 +44,8 @@ const filterRequest = (command, context) => {
   };
 };
 
-function wrap({ timeline, data = {} } = {}) {
+async function wrap({ timeline, data = {} } = {}) {
+  await loadModule();
   if (!redis) {
     debug('redis plugin not accessible from trace plugin. Skipping.');
     return false;

--- a/src/plugins/redis.test.js
+++ b/src/plugins/redis.test.js
@@ -87,8 +87,8 @@ xtest('Redis works as normal if wrap is not called', done => {
   client.set('testString', expectedStr, setCb);
 });
 
-test('Bails if timeline is not instance of performance-node', () => {
-  const bool = wrap({ timeline: [] });
+test('Bails if timeline is not instance of performance-node', async () => {
+  const bool = await wrap({ timeline: [] });
   expect(bool).toBe(false);
 });
 


### PR DESCRIPTION
Attempts to add the lambda task root to the NODE_PATH, and load traced plugins directly as a fallback.  Makes loading asynchronous, so required refactoring.  

(Tests pass, but should get additional refactoring.) Smoke tests pass. Not yet tested with layers directly.  

Closes #70 